### PR TITLE
Fix: Do not instantiate classes when calling static functions.

### DIFF
--- a/advisors/VehiclesAdvisor.nut
+++ b/advisors/VehiclesAdvisor.nut
@@ -42,11 +42,11 @@ function VehiclesAdvisor::GetVehiclesWaiting(stationLocation, connection) {
 			if (!isRail && AIVehicle.GetVehicleType(vehicleID) == AIVehicle.VT_RAIL)
 				isRail = true;
 
-			if (AIMap().DistanceManhattan(AIVehicle().GetLocation(vehicleID), stationLocation) > 0 && 
-				(AIMap().DistanceManhattan(AIVehicle().GetLocation(vehicleID), stationLocation) < (isAir ? 30 : 7) || isRail) &&
-				(AIVehicle().GetCurrentSpeed(vehicleID) < 10 || isAir) &&
+			if (AIMap.DistanceManhattan(AIVehicle.GetLocation(vehicleID), stationLocation) > 0 && 
+				(AIMap.DistanceManhattan(AIVehicle.GetLocation(vehicleID), stationLocation) < (isAir ? 30 : 7) || isRail) &&
+				(AIVehicle.GetCurrentSpeed(vehicleID) < 10 || isAir) &&
 				(AIVehicle.GetState(vehicleID) == AIVehicle.VS_RUNNING || AIVehicle.GetState(vehicleID) == AIVehicle.VS_BROKEN) &&
-				AIOrder().GetOrderDestination(vehicleID, AIOrder.ORDER_CURRENT) == stationLocation) {
+				AIOrder.GetOrderDestination(vehicleID, AIOrder.ORDER_CURRENT) == stationLocation) {
 
 				nrVehicles--;
 					
@@ -72,7 +72,7 @@ function VehiclesAdvisor::Update(loopCounter) {
 
 		// Make sure we don't update a connection to often!
 		local currentDate = AIDate.GetCurrentDate();
-		if (Date().GetDaysBetween(connection.lastChecked, currentDate) < 30) {
+		if (Date.GetDaysBetween(connection.lastChecked, currentDate) < 30) {
 			continue;
 		}
 		


### PR DESCRIPTION
Because of recent changes in OpenTTD (OpenTTD/OpenTTD@4b677e8), the default consturtors does not exported for some classes. Since then NoNoCab (and NoCab too) crashes with the message: This class is not instantiable.

```
dbg: [script:0] [10] [S] Your script made an error: This class is not instantiable
dbg: [script:0] [10] [S] 
dbg: [script:0] [10] [S] *FUNCTION [GetVehiclesWaiting()] nonocab-8.tar/nonocab-8/advisors/VehiclesAdvisor.nut line [45]
dbg: [script:0] [10] [S] *FUNCTION [Update()] nonocab-8.tar/nonocab-8/advisors/VehiclesAdvisor.nut line [91]
dbg: [script:0] [10] [S] *FUNCTION [ScheduleAndExecute()] nonocab-8.tar/nonocab-8/management/threads/Planner.nut line [41]
dbg: [script:0] [10] [S] *FUNCTION [Start()] nonocab-8.tar/nonocab-8/main.nut line [449]
```